### PR TITLE
Added folder to save files

### DIFF
--- a/fmdpy/download.py
+++ b/fmdpy/download.py
@@ -62,7 +62,7 @@ def main_dl(
                 to_delete.append(tf_song.name)
                 to_delete.append(tf_thumb.name)
 
-            output_file = directory + f"/{song_obj.artist}-{song_obj.title}({song_obj.year})"\
+            output_file = directory + f"/{song_obj.artist}/{song_obj.artist}-{song_obj.title}({song_obj.year})"
                 .replace(' ', '_').lower()
             if os.path.isfile(output_file):
                 print(f"[WARNING]: File {output_file + '.mp4'} exist, skipping")

--- a/fmdpy/download.py
+++ b/fmdpy/download.py
@@ -62,8 +62,8 @@ def main_dl(
                 to_delete.append(tf_song.name)
                 to_delete.append(tf_thumb.name)
 
-            output_file = directory + f"/{song_obj.artist}/{song_obj.artist}-{song_obj.title}({song_obj.year})"
-                .replace(' ', '_').lower()
+            output_file = directory + f"/{song_obj.artist}/{song_obj.artist}-\
+                          {song_obj.title}({song_obj.year})".replace(' ', '_').lower()
             if os.path.isfile(output_file):
                 print(f"[WARNING]: File {output_file + '.mp4'} exist, skipping")
                 return False

--- a/scripts/ci_test.py
+++ b/scripts/ci_test.py
@@ -23,7 +23,7 @@ args = [sys.executable, '-m', 'fmdpy', '-c', '10',
 with subprocess.Popen([*args, 'mp3'],
                       stdin=subprocess.PIPE, stdout=subprocess.PIPE) as cp:
     cp.communicate('3-6,1\n'.encode())
-assert len(glob.glob('./tmp_test/tmp_test2/*.mp3')) == 5
+assert len(glob.glob('./tmp_test/*.mp3')) == 5
 
 with subprocess.Popen([*args, 'opus'],
                       stdin=subprocess.PIPE, stdout=subprocess.PIPE) as cp:

--- a/scripts/ci_test.py
+++ b/scripts/ci_test.py
@@ -23,7 +23,7 @@ args = [sys.executable, '-m', 'fmdpy', '-c', '10',
 with subprocess.Popen([*args, 'mp3'],
                       stdin=subprocess.PIPE, stdout=subprocess.PIPE) as cp:
     cp.communicate('3-6,1\n'.encode())
-assert len(glob.glob('./tmp_test/*.mp3')) == 5
+assert len(glob.glob('./tmp_test/tmp_test2/*.mp3')) == 5
 
 with subprocess.Popen([*args, 'opus'],
                       stdin=subprocess.PIPE, stdout=subprocess.PIPE) as cp:


### PR DESCRIPTION
Currently, fmdpy saves everything in the root folder, making importing difficult (for example, `beets` only imports files in folders). Added an artist folder under which files will be saved (we can even use album, if you prefer that). This is the same format that is used by other similar programs (e.g., deemix). 